### PR TITLE
feat!: adding transparency and tileOutputFormat (MAPCO-2580)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@map-colonies/error-types": "^1.1.0",
         "@map-colonies/express-access-log-middleware": "^0.0.3",
         "@map-colonies/js-logger": "^0.0.3",
-        "@map-colonies/mc-model-types": "^13.2.1",
+        "@map-colonies/mc-model-types": "^14.0.0",
         "@map-colonies/openapi-express-viewer": "^2.0.1",
         "@map-colonies/read-pkg": "0.0.1",
         "@map-colonies/telemetry": "3.0.0",
@@ -2886,9 +2886,9 @@
       }
     },
     "node_modules/@map-colonies/mc-model-types": {
-      "version": "13.2.1",
-      "resolved": "https://registry.npmjs.org/@map-colonies/mc-model-types/-/mc-model-types-13.2.1.tgz",
-      "integrity": "sha512-e7FFBOBhmJS1BIWSXUx0GvydIrRyTcz8uGxBS41Xp+MeuyYhPKFzoGdXN10NIOCRW2iZ8hitZCA5qnZ0rMdnFg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@map-colonies/mc-model-types/-/mc-model-types-14.0.0.tgz",
+      "integrity": "sha512-5uTiBZ5/JlG3Nvjs0/V0DYnGK5QxxSg9ieLIK4PBIzJ2liZx83bOwbGODsKzkquosHRY2nhtB7qmvAgz1xpOLQ==",
       "dependencies": {
         "@types/geojson": "^7946.0.7",
         "reflect-metadata": "^0.1.13"
@@ -6618,9 +6618,9 @@
       }
     },
     "node_modules/dezalgo": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-      "integrity": "sha512-K7i4zNfT2kgQz3GylDw40ot9GAE47sFZ9EXHFSPP6zONLgH6kWXE0KWJchkbQJLBkRazq4APwZ4OwiFFlT95OQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
       "dev": true,
       "dependencies": {
         "asap": "^2.0.0",
@@ -8051,25 +8051,28 @@
       }
     },
     "node_modules/formidable": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.0.1.tgz",
-      "integrity": "sha512-rjTMNbp2BpfQShhFbR3Ruk3qk2y9jKpvMW78nJgx8QKtxjDVrwbZG+wvDOmVbifHyOUOQJXxqEy6r0faRrPzTQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.1.tgz",
+      "integrity": "sha512-0EcS9wCFEzLvfiks7omJ+SiYJAiD+TzK4Pcw1UlUoGnhUxDcMKjt0P7x8wEb0u6OHu8Nb98WG3nxtlF5C7bvUQ==",
       "dev": true,
       "dependencies": {
-        "dezalgo": "1.0.3",
-        "hexoid": "1.0.0",
-        "once": "1.4.0",
-        "qs": "6.9.3"
+        "dezalgo": "^1.0.4",
+        "hexoid": "^1.0.0",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
       },
       "funding": {
         "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/formidable/node_modules/qs": {
-      "version": "6.9.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
-      "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
       "dev": true,
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
       "engines": {
         "node": ">=0.6"
       },
@@ -16606,9 +16609,9 @@
       }
     },
     "@map-colonies/mc-model-types": {
-      "version": "13.2.1",
-      "resolved": "https://registry.npmjs.org/@map-colonies/mc-model-types/-/mc-model-types-13.2.1.tgz",
-      "integrity": "sha512-e7FFBOBhmJS1BIWSXUx0GvydIrRyTcz8uGxBS41Xp+MeuyYhPKFzoGdXN10NIOCRW2iZ8hitZCA5qnZ0rMdnFg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@map-colonies/mc-model-types/-/mc-model-types-14.0.0.tgz",
+      "integrity": "sha512-5uTiBZ5/JlG3Nvjs0/V0DYnGK5QxxSg9ieLIK4PBIzJ2liZx83bOwbGODsKzkquosHRY2nhtB7qmvAgz1xpOLQ==",
       "requires": {
         "@types/geojson": "^7946.0.7",
         "reflect-metadata": "^0.1.13"
@@ -19471,9 +19474,9 @@
       "dev": true
     },
     "dezalgo": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-      "integrity": "sha512-K7i4zNfT2kgQz3GylDw40ot9GAE47sFZ9EXHFSPP6zONLgH6kWXE0KWJchkbQJLBkRazq4APwZ4OwiFFlT95OQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
       "dev": true,
       "requires": {
         "asap": "^2.0.0",
@@ -20567,22 +20570,25 @@
       }
     },
     "formidable": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.0.1.tgz",
-      "integrity": "sha512-rjTMNbp2BpfQShhFbR3Ruk3qk2y9jKpvMW78nJgx8QKtxjDVrwbZG+wvDOmVbifHyOUOQJXxqEy6r0faRrPzTQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.1.tgz",
+      "integrity": "sha512-0EcS9wCFEzLvfiks7omJ+SiYJAiD+TzK4Pcw1UlUoGnhUxDcMKjt0P7x8wEb0u6OHu8Nb98WG3nxtlF5C7bvUQ==",
       "dev": true,
       "requires": {
-        "dezalgo": "1.0.3",
-        "hexoid": "1.0.0",
-        "once": "1.4.0",
-        "qs": "6.9.3"
+        "dezalgo": "^1.0.4",
+        "hexoid": "^1.0.0",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
       },
       "dependencies": {
         "qs": {
-          "version": "6.9.3",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
-          "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw==",
-          "dev": true
+          "version": "6.11.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+          "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+          "dev": true,
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@map-colonies/error-types": "^1.1.0",
     "@map-colonies/express-access-log-middleware": "^0.0.3",
     "@map-colonies/js-logger": "^0.0.3",
-    "@map-colonies/mc-model-types": "^13.2.1",
+    "@map-colonies/mc-model-types": "^14.0.0",
     "@map-colonies/openapi-express-viewer": "^2.0.1",
     "@map-colonies/read-pkg": "0.0.1",
     "@map-colonies/telemetry": "3.0.0",

--- a/src/DAL/migration/fullSchema.sql
+++ b/src/DAL/migration/fullSchema.sql
@@ -54,7 +54,6 @@ CREATE TABLE records
     display_path text COLLATE pg_catalog."default" NOT NULL
     transparency text COLLATE pg_catalog."default" NOT NULL
     tile_output_format text COLLATE pg_catalog."default" NOT NULL
-
 );
 
 

--- a/src/DAL/migration/fullSchema.sql
+++ b/src/DAL/migration/fullSchema.sql
@@ -52,6 +52,9 @@ CREATE TABLE records
     CONSTRAINT records_pkey PRIMARY KEY (identifier),
     CONSTRAINT unique_record_values UNIQUE (product_id, product_version, product_type),
     display_path text COLLATE pg_catalog."default" NOT NULL
+    transparency text COLLATE pg_catalog."default" NOT NULL
+    tile_output_format text COLLATE pg_catalog."default" NOT NULL
+
 );
 
 

--- a/src/DAL/migration/v3.0.0.sql
+++ b/src/DAL/migration/v3.0.0.sql
@@ -1,3 +1,5 @@
+SET search_path TO "RasterCatalogManager", public; -- CHANGE SCHEMA NAME TO MATCH ENVIRONMENT
+
 ALTER TABLE "records" ALTER identifier DROP DEFAULT;
 ALTER TABLE "records" ADD COLUMN display_path text;
 UPDATE "records" SET display_path=uuid_generate_v4();

--- a/src/DAL/migration/v4.0.0.sql
+++ b/src/DAL/migration/v4.0.0.sql
@@ -1,0 +1,9 @@
+SET search_path TO "RasterCatalogManager", public; -- CHANGE SCHEMA NAME TO MATCH ENVIRONMENT
+
+ALTER TABLE "records" ADD COLUMN transparency text;
+UPDATE "records" SET transparency='TRANSPARENT';
+ALTER TABLE "records" ALTER transparency SET NOT NULL;
+
+ALTER TABLE "records" ADD COLUMN tile_output_format text;
+UPDATE "records" SET tile_output_format='PNG';
+ALTER TABLE "records" ALTER tile_output_format SET NOT NULL;

--- a/tests/integration/records/records.spec.ts
+++ b/tests/integration/records/records.spec.ts
@@ -2,6 +2,7 @@ import httpStatusCodes from 'http-status-codes';
 import { container } from 'tsyringe';
 import { trace } from '@opentelemetry/api';
 import jsLogger from '@map-colonies/js-logger';
+import { TileOutputFormat, Transparency } from '@map-colonies/mc-model-types';
 import { SERVICES } from '../../../src/common/constants';
 import { getApp } from '../../../src/app';
 import { RecordRepository } from '../../../src/DAL/repositories/recordRepository';
@@ -47,6 +48,8 @@ const testMetadata = {
   creationDate: '2021-06-07T05:41:43.032Z',
   ingestionDate: '2021-06-07T05:41:43.032Z',
   maxResolutionDeg: 0.05,
+  transparency: Transparency.TRANSPARENT,
+  tileOutputFormat: TileOutputFormat.PNG,
   includedInBests: [],
 };
 
@@ -272,6 +275,7 @@ describe('records', () => {
     // https://github.com/cdimascio/express-openapi-validator/issues/239
     // additionalProperties: false
 
+    // eslint-disable-next-line jest/no-commented-out-tests
     // it('should return status code 400 on PUT request with invalid body', async () => {
     //   const recordCountMock = recordRepositoryMocks.countMock;
     //   const response = await requestSender.updateResource('9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d', {


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✔                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✔                                                                       |

Bumping mc-models major version to 14.0.0
it includes 2 new fields:

* Create a new migration file and update fullScheme
* Transparency as mandatory field and pycsw field (TRANSPARENT | OPAQUE)
* TileOutputFormat as mandatory internal and self-calculated fields (PNG | JPEG)
