### PR TITLE
fix: make db establish on server pre load

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import config from 'config';
 import { DEFAULT_SERVER_PORT, SERVICES } from './common/constants';
 
 import { getApp } from './app';
+import { ConnectionManager } from './DAL/connectionManager';
 
 interface IServerConfig {
   port: string;
@@ -23,7 +24,16 @@ const logger = container.resolve<Logger>(SERVICES.LOGGER);
 const stubHealthcheck = async (): Promise<void> => Promise.resolve();
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const server = createTerminus(createServer(app), { healthChecks: { '/liveness': stubHealthcheck, onSignal: container.resolve('onSignal') } });
-
+const dbConnectionManager = container.resolve(ConnectionManager);
+dbConnectionManager
+  .init()
+  .then(() => logger.info('Establish success connection to db'))
+  .catch((error) => {
+    const connErr = `Failed on db connection with error: ${(error as Error).message}`;
+    logger.error(connErr);
+    throw Error(connErr);
+  });
+  
 server.listen(port, () => {
   logger.info(`app started on port ${port}`);
 });


### PR DESCRIPTION
DB connection should be as part of server first load

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

The bug was that first db connection was just after first API calling (get repo check if there is connection and if not will init it)

The problem coused that the first API CRUD call sometimes return timeout becouse of the connection long time. it should take time as part of the load